### PR TITLE
将“放大化”改为“巨型生物群系”以避免产生歧义

### DIFF
--- a/src/exportdialog.cpp
+++ b/src/exportdialog.cpp
@@ -255,7 +255,7 @@ void ExportDialog::update()
     wgen += ", ";
     if (dim == 0) {
         wgen += tr("主世界");
-        if (wi.large) wgen += tr("/放大化");
+        if (wi.large) wgen += tr("/巨型群系");
     } else if (dim == -1) {
         wgen += tr("下界");
     } else if (dim == +1) {

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -87,7 +87,7 @@
           <item row="1" column="0" colspan="2">
            <widget class="QCheckBox" name="checkLarge">
             <property name="text">
-             <string>放大化群系</string>
+             <string>巨型生物群系</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
在放大化中，群系分布并没有变化，仅在地形生成上有明显差异；
软件原文为“**Large Biomes**”，根据译名标准化，应当译为“**巨型生物群系**”而非“放大化”（Amplified）；
二者不是同一世界预设类型。